### PR TITLE
refactor: shared lib, caching, themes, SVG error cards, HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,103 +1,113 @@
-
 # Lastly
 
 Lastly is a Next.js project that generates dynamic SVG images showcasing your Last.fm listening statistics. These SVGs are designed to be embedded directly into GitHub READMEs, profiles, or any markdown-supported platform.
 
-It supports multiple endpoints to visualize artists, tracks, albums, and recent activity for any Last.fm user - all rendered server-side as SVGs.
-
+It supports multiple endpoints to visualize artists, tracks, albums, and recent activity for any Last.fm user — all rendered server-side as SVGs, with CDN caching and multiple color themes.
 
 ## API Endpoints
 
-The project provides the following API endpoints:
-
-| Endpoint              | Description                                |
-| --------------------- | ------------------------------------------ |
-| `/api/overall`        | Fetches and visualizes overall statistics  |
-| `/api/top-artists`    | Fetches and visualizes top artists         |
-| `/api/top-tracks`     | Fetches and visualizes top tracks          |
-| `/api/top-albums`     | Fetches and visualizes top albums          |
-| `/api/recent`         | Fetches and visualizes recent tracks       |
-
+| Endpoint           | Description                               |
+| ------------------ | ----------------------------------------- |
+| `/api/overall`     | Fetches and visualizes overall statistics |
+| `/api/top-artists` | Fetches and visualizes top artists        |
+| `/api/top-tracks`  | Fetches and visualizes top tracks         |
+| `/api/top-albums`  | Fetches and visualizes top albums         |
+| `/api/recent`      | Fetches and visualizes recent tracks      |
 
 ## Embedding in README
 
-To embed these images in your GitHub README (or other markdown content):
+Use markdown:
 
-1. Use the following markdown syntax to display the overall statistics for a user.
-
-```md
-![Overall Statistics](https://lastly.nisarga.me/api/overall?username=USERNAME&period=overall)
+```
+![Overall Statistics](https://lastly.nisarga.me/api/overall?username=USERNAME&period=overall&theme=default)
 ```
 
-Replace `USERNAME` with your Last.fm username and `PERIOD` with the desired period (see options below).
+Or HTML for more control (e.g. centering):
 
-2. Alternatively, you can use HTML for more control over formatting (e.g., centering the image):
-
-```html
-<img src="https://lastly.nisarga.me/api/overall?username=USERNAME&period=overall" alt="Overall Statistics" align="center">
+```
+<img src="https://lastly.nisarga.me/api/overall?username=USERNAME&theme=dracula" alt="Overall Statistics" align="center">
 ```
 
+Replace `USERNAME` with your Last.fm username.
 
-### Options
+### Query Options
 
-- **`username`**: Your [Last.fm](https://www.last.fm) username.
-- **`period`**: Can be set to:
-  - `overall`: All-time statistics (default)
-  - `7day`: Last 7 days
-  - `1month`: Last month
-  - `3month`: Last 3 months
-  - `6month`: Last 6 months
-  - `12month`: Last year
+- **`username`** *(required)*: Your [Last.fm](https://www.last.fm) username.
+- **`period`**: Time range for stats. Applies to `overall`, `top-artists`, `top-tracks`, `top-albums`.
+  - `overall` (default), `7day`, `1month`, `3month`, `6month`, `12month`
+- **`theme`**: Color theme. Defaults to `default`.
+  - `default`, `dark`, `light`, `dracula`, `gruvbox`, `tokyonight`, `radical`, `nord`, `catppuccin`
 
-If `period` is not specified, the default is `overall`.
+If `period` or `theme` is omitted, sensible defaults are used. Invalid values fall back to defaults.
 
+### Examples
+
+```
+![Top Artists](https://lastly.nisarga.me/api/top-artists?username=USERNAME&period=7day&theme=tokyonight)
+![Recent](https://lastly.nisarga.me/api/recent?username=USERNAME&theme=nord)
+```
+
+## Caching
+
+Responses are served with `Cache-Control` headers so the CDN can serve cards without re-hitting Last.fm on every render:
+
+- `overall`, `top-*` → cached ~6 hours
+- `recent` → cached ~5 minutes (activity changes often)
+
+Errors (e.g. unknown user) return a readable SVG error card with a short cache, so your README never shows a broken image.
 
 ## Self-Hosting Guide
 
-Follow the steps below to set up and run the project on your local machine:
-
 1. **Clone the repository**:
 
-   ```bash
-   git clone https://github.com/ni5arga/lastly.git
-   cd lastly
-   ```
+```
+git clone https://github.com/ni5arga/lastly.git
+cd lastly
+```
 
 2. **Install dependencies**:
 
-   ```bash
-   npm install
-   # or
-   yarn install
-   ```
+```
+npm install
+```
 
-3. **Configure environment**:
+3. **Configure environment**: Create a `.env.local` in the root and add your Last.fm API key:
 
-   Create a `.env.local` file in the root directory and add your Last.fm API key.
-
-   ```env
-   LASTFM_API_KEY=your_lastfm_api_key
-   ```
+```
+LASTFM_API_KEY=your_lastfm_api_key
+```
 
 4. **Run the development server**:
 
-   ```bash
-   npm run dev
-   # or
-   yarn dev
-   ```
+```
+npm run dev
+```
 
-   Open [http://localhost:3000](http://localhost:3000) with your browser to view the project.
-
+Open <http://localhost:3000> with your browser to view the project.
 
 ## Deploy with Vercel
 
-Deploy the project to Vercel using the button below. Make sure to set up your environment variable (`LASTFM_API_KEY`) during the process.
+Deploy to Vercel and set the `LASTFM_API_KEY` environment variable during setup.
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fni5arga%2FLastly&env=LASTFM_API_KEY)
 
+## Project Structure
+
+```
+src/
+├── lib/
+│   ├── lastfm.ts   # Last.fm API client: typed fetchers, validation, timeouts, avatar handling
+│   └── svg.ts      # Themes, SVG building blocks, error cards, cached response senders
+└── pages/
+    ├── index.tsx   # Redirects to the GitHub repo
+    └── api/
+        ├── overall.ts
+        ├── recent.ts
+        ├── top-albums.ts
+        ├── top-artists.ts
+        └── top-tracks.ts
+```
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
+This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.

--- a/src/lib/lastfm.ts
+++ b/src/lib/lastfm.ts
@@ -1,0 +1,138 @@
+import axios from 'axios';
+
+const BASE = 'https://ws.audioscrobbler.com/2.0/';
+const TIMEOUT = 8000; // ms — prevents the serverless function from hanging on slow Last.fm
+
+/** Thrown for any Last.fm / network failure with a user-readable message. */
+export class LastfmError extends Error {}
+
+function apiKey(): string {
+  const key = process.env.LASTFM_API_KEY;
+  if (!key) throw new LastfmError('Server is missing LASTFM_API_KEY');
+  return key;
+}
+
+/* ------------------------------------------------------------------ */
+/* Query param parsing                                                 */
+/* ------------------------------------------------------------------ */
+
+export type Period = 'overall' | '7day' | '1month' | '3month' | '6month' | '12month';
+const VALID_PERIODS: Period[] = ['overall', '7day', '1month', '3month', '6month', '12month'];
+
+export function parsePeriod(p: unknown): Period {
+  const val = Array.isArray(p) ? p[0] : p;
+  return VALID_PERIODS.includes(val as Period) ? (val as Period) : 'overall';
+}
+
+export function parseUsername(u: unknown): string | null {
+  const name = Array.isArray(u) ? u[0] : u;
+  if (!name || typeof name !== 'string' || !name.trim()) return null;
+  return name.trim();
+}
+
+/* ------------------------------------------------------------------ */
+/* Core request                                                        */
+/* ------------------------------------------------------------------ */
+
+async function call(method: string, params: Record<string, string>): Promise<any> {
+  const url = new URL(BASE);
+  url.searchParams.set('method', method);
+  url.searchParams.set('api_key', apiKey());
+  url.searchParams.set('format', 'json');
+  // URL-encodes usernames with spaces / special chars (old code didn't)
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+
+  try {
+    const { data } = await axios.get(url.toString(), { timeout: TIMEOUT });
+    // Last.fm returns 200 with { error, message } for bad users etc.
+    if (data && data.error) throw new LastfmError(data.message || 'Last.fm API error');
+    return data;
+  } catch (e) {
+    if (e instanceof LastfmError) throw e;
+    if (axios.isAxiosError(e) && e.response?.data?.message) {
+      throw new LastfmError(e.response.data.message);
+    }
+    throw new LastfmError('Could not reach Last.fm');
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Typed responses (only the fields we use)                            */
+/* ------------------------------------------------------------------ */
+
+export interface LfmImage { '#text': string; size: string }
+
+export interface UserInfo {
+  name: string;
+  playcount: string;
+  artist_count: string;
+  track_count?: string;
+  album_count?: string;
+  image: LfmImage[];
+}
+
+export interface TopArtist { name: string; playcount: string }
+export interface TopTrack { name: string; playcount: string; artist: { name: string } }
+export interface TopAlbum { name: string; playcount: string; artist: { name: string } }
+export interface RecentTrack {
+  name: string;
+  artist: { '#text': string };
+  '@attr'?: { nowplaying?: string };
+}
+
+/* ------------------------------------------------------------------ */
+/* Fetchers                                                            */
+/* ------------------------------------------------------------------ */
+
+export async function getUserInfo(user: string): Promise<UserInfo> {
+  const d = await call('user.getinfo', { user });
+  return d.user as UserInfo;
+}
+
+export async function getTopArtists(user: string, period: Period, limit = 5): Promise<TopArtist[]> {
+  const d = await call('user.gettopartists', { user, period, limit: String(limit) });
+  return (d.topartists?.artist ?? []) as TopArtist[];
+}
+
+export async function getTopTracks(user: string, period: Period, limit = 5): Promise<TopTrack[]> {
+  const d = await call('user.gettoptracks', { user, period, limit: String(limit) });
+  return (d.toptracks?.track ?? []) as TopTrack[];
+}
+
+export async function getTopAlbums(user: string, period: Period, limit = 5): Promise<TopAlbum[]> {
+  const d = await call('user.gettopalbums', { user, period, limit: String(limit) });
+  return (d.topalbums?.album ?? []) as TopAlbum[];
+}
+
+export async function getRecentTracks(user: string, limit = 5): Promise<RecentTrack[]> {
+  const d = await call('user.getrecenttracks', { user, limit: String(limit + 1) });
+  const tracks = (d.recenttracks?.track ?? []) as RecentTrack[];
+  return tracks.slice(0, limit); // hard cap at 5
+}
+
+
+/* ------------------------------------------------------------------ */
+/* Avatar helpers                                                      */
+/* ------------------------------------------------------------------ */
+
+/** Pick the best non-empty image URL from a Last.fm image array. */
+export function pickImage(images: LfmImage[] | undefined): string | undefined {
+  if (!Array.isArray(images)) return undefined;
+  const large = images[2]?.['#text'];
+  if (large) return large;
+  for (let i = images.length - 1; i >= 0; i--) {
+    if (images[i]?.['#text']) return images[i]['#text'];
+  }
+  return undefined;
+}
+
+/** Download an avatar and inline it as base64. Returns null on any failure. */
+export async function fetchAvatar(url: string | undefined): Promise<string | null> {
+  if (!url) return null;
+  try {
+    const { data } = await axios.get(url, { responseType: 'arraybuffer', timeout: TIMEOUT });
+    return `data:image/png;base64,${Buffer.from(data, 'binary').toString('base64')}`;
+  } catch {
+    return null; // missing avatar should never break the card
+  }
+}

--- a/src/lib/svg.ts
+++ b/src/lib/svg.ts
@@ -1,0 +1,138 @@
+import type { NextApiResponse } from 'next';
+
+/* ------------------------------------------------------------------ */
+/* Themes                                                              */
+/* ------------------------------------------------------------------ */
+
+export interface Theme {
+  /** solid color, or [from, to] for a diagonal gradient */
+  bg: string | [string, string];
+  title: string;
+  section: string;
+  item: string;
+  index: string;
+  subtitle: string;
+  stats: string;
+}
+
+export const THEMES: Record<string, Theme> = {
+  default:    { bg: ['#1a2a3a', '#3d6073'], title: '#ffffff', section: '#ffd700', item: '#f5f5f5', index: '#ff6b6b', subtitle: '#e0e0e0', stats: '#f5f5f5' },
+  dark:       { bg: '#0d1117', title: '#ffffff', section: '#58a6ff', item: '#c9d1d9', index: '#f778ba', subtitle: '#8b949e', stats: '#c9d1d9' },
+  light:      { bg: '#ffffff', title: '#24292f', section: '#0969da', item: '#24292f', index: '#cf222e', subtitle: '#57606a', stats: '#1a7f37' },
+  dracula:    { bg: '#282a36', title: '#f8f8f2', section: '#bd93f9', item: '#f8f8f2', index: '#ff79c6', subtitle: '#6272a4', stats: '#50fa7b' },
+  gruvbox:    { bg: '#282828', title: '#fbf1c7', section: '#fabd2f', item: '#ebdbb2', index: '#fe8019', subtitle: '#a89984', stats: '#b8bb26' },
+  tokyonight: { bg: '#1a1b27', title: '#70a5fd', section: '#bf91f3', item: '#a9b1d6', index: '#38bdae', subtitle: '#565f89', stats: '#9ece6a' },
+  radical:    { bg: '#141321', title: '#fe428e', section: '#f8d847', item: '#a9fef7', index: '#fe428e', subtitle: '#a9fef7', stats: '#a9fef7' },
+  nord:       { bg: '#2e3440', title: '#eceff4', section: '#88c0d0', item: '#e5e9f0', index: '#bf616a', subtitle: '#81a1c1', stats: '#a3be8c' },
+  catppuccin: { bg: '#1e1e2e', title: '#cdd6f4', section: '#cba6f7', item: '#cdd6f4', index: '#f38ba8', subtitle: '#9399b2', stats: '#a6e3a1' },
+};
+
+export function getTheme(name: unknown): Theme {
+  const key = (Array.isArray(name) ? name[0] : name);
+  if (typeof key === 'string' && THEMES[key.toLowerCase()]) return THEMES[key.toLowerCase()];
+  return THEMES.default;
+}
+
+/* ------------------------------------------------------------------ */
+/* Text helpers                                                        */
+/* ------------------------------------------------------------------ */
+
+export function escapeXML(str: string): string {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+/** Truncate long names so they don't overflow the card width. */
+export function truncate(str: string, max: number): string {
+  if (!str) return '';
+  return str.length <= max ? str : str.slice(0, max - 1).trimEnd() + '…';
+}
+
+export function formatNumber(n: string | number): string {
+  const num = Number(n);
+  return Number.isFinite(num) ? num.toLocaleString('en-US') : String(n);
+}
+
+/* ------------------------------------------------------------------ */
+/* SVG building blocks                                                 */
+/* ------------------------------------------------------------------ */
+
+export function svgDefs(theme: Theme): string {
+  if (!Array.isArray(theme.bg)) return '';
+  return `<defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="${theme.bg[0]}"/>
+      <stop offset="100%" stop-color="${theme.bg[1]}"/>
+    </linearGradient>
+  </defs>`;
+}
+
+export function bgFill(theme: Theme): string {
+  return Array.isArray(theme.bg) ? 'url(#grad)' : theme.bg;
+}
+
+export function svgStyle(theme: Theme): string {
+  const f = `'Segoe UI', Ubuntu, 'Helvetica Neue', sans-serif`;
+  return `<style>
+    .title { font: bold 22px ${f}; fill: ${theme.title}; }
+    .section-title { font: bold 18px ${f}; fill: ${theme.section}; }
+    .item { font: 14px ${f}; fill: ${theme.item}; }
+    .index { font: bold 14px ${f}; fill: ${theme.index}; }
+    .subtitle { font: italic 12px ${f}; fill: ${theme.subtitle}; }
+    .stats { font: bold 12px ${f}; fill: ${theme.stats}; }
+  </style>`;
+}
+
+/** Circular avatar. Returns '' when there is no avatar so the card still renders. */
+export function avatarCircle(base64: string | null, cx: number, cy: number, r: number): string {
+  if (!base64) return '';
+  const id = `clip-${cx}-${cy}`;
+  return `<clipPath id="${id}"><circle cx="${cx}" cy="${cy}" r="${r}"/></clipPath>
+    <circle cx="${cx}" cy="${cy}" r="${r}" fill="#ffffff"/>
+    <image href="${base64}" x="${cx - r}" y="${cy - r}" width="${r * 2}" height="${r * 2}" clip-path="url(#${id})" preserveAspectRatio="xMidYMid slice"/>`;
+}
+
+/** Wrap inner SVG content with the shared frame (background + defs + styles). */
+export function card(width: number, height: number, theme: Theme, inner: string): string {
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}" fill="none" role="img">
+  ${svgDefs(theme)}
+  ${svgStyle(theme)}
+  <rect width="${width}" height="${height}" rx="10" fill="${bgFill(theme)}"/>
+  ${inner}
+</svg>`;
+}
+
+export function errorCard(message: string, theme: Theme): string {
+  const w = 500, h = 120;
+  const inner = `<text x="24" y="48" class="title">⚠ Lastly</text>
+    <text x="24" y="82" class="item">${escapeXML(message)}</text>`;
+  return card(w, h, theme, inner);
+}
+
+/* ------------------------------------------------------------------ */
+/* Response senders (with CDN caching)                                 */
+/* ------------------------------------------------------------------ */
+
+/**
+ * @param maxAge seconds the CDN may serve this card before revalidating.
+ *  Cuts Last.fm calls + latency dramatically vs. the old no-cache version.
+ */
+export function sendSvg(res: NextApiResponse, svg: string, maxAge = 21600): void {
+  res.setHeader('Content-Type', 'image/svg+xml; charset=utf-8');
+  res.setHeader(
+    'Cache-Control',
+    `public, max-age=0, s-maxage=${maxAge}, stale-while-revalidate=${Math.floor(maxAge / 2)}`,
+  );
+  res.status(200).send(svg);
+}
+
+/** Errors return 200 + an SVG card so the README shows a readable message, not a broken image. Cached only briefly. */
+export function sendError(res: NextApiResponse, message: string, theme: Theme): void {
+  res.setHeader('Content-Type', 'image/svg+xml; charset=utf-8');
+  res.setHeader('Cache-Control', 'public, max-age=0, s-maxage=30');
+  res.status(200).send(errorCard(message, theme));
+}

--- a/src/pages/api/overall.ts
+++ b/src/pages/api/overall.ts
@@ -1,126 +1,69 @@
-import axios from 'axios';
-import { NextApiRequest, NextApiResponse } from 'next';
-
-function escapeXML(str: string) {
-  return str.replace(/&/g, "&amp;")
-            .replace(/</g, "&lt;")
-            .replace(/>/g, "&gt;")
-            .replace(/"/g, "&quot;")
-            .replace(/'/g, "&#039;")
-            .replace(/\$/g, "&#36;") 
-            .replace(/%/g, "&#37;");  
-}
+import type { NextApiRequest, NextApiResponse } from 'next';
+import * as svg from '@/lib/svg';
+import * as lfm from '@/lib/lastfm';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const username = Array.isArray(req.query.username) ? req.query.username[0] : req.query.username;
-  const period = req.query.period || 'overall'; // Default to 'overall' if no period is provided.
-  const apiKey = process.env.LASTFM_API_KEY;
-
-  const lastFmTopArtistsUrl = `http://ws.audioscrobbler.com/2.0/?method=user.gettopartists&user=${username}&period=${period}&api_key=${apiKey}&format=json`;
-  const lastFmTopTracksUrl = `http://ws.audioscrobbler.com/2.0/?method=user.gettoptracks&user=${username}&period=${period}&api_key=${apiKey}&format=json`;
-  const lastFmTopAlbumsUrl = `http://ws.audioscrobbler.com/2.0/?method=user.gettopalbums&user=${username}&period=${period}&api_key=${apiKey}&format=json`;
-  const lastFmRecentTracksUrl = `http://ws.audioscrobbler.com/2.0/?method=user.getrecenttracks&user=${username}&api_key=${apiKey}&format=json`;
-  const lastFmUserInfoUrl = `http://ws.audioscrobbler.com/2.0/?method=user.getinfo&user=${username}&api_key=${apiKey}&format=json`;
-
+  const theme = svg.getTheme(req.query.theme);
   try {
-    const [
-      topArtistsResponse,
-      topTracksResponse,
-      topAlbumsResponse,
-      recentTracksResponse,
-      userInfoResponse,
-    ] = await Promise.all([
-      axios.get(lastFmTopArtistsUrl),
-      axios.get(lastFmTopTracksUrl),
-      axios.get(lastFmTopAlbumsUrl),
-      axios.get(lastFmRecentTracksUrl),
-      axios.get(lastFmUserInfoUrl),
+    const username = lfm.parseUsername(req.query.username);
+    if (!username) return svg.sendError(res, 'username query param is required', theme);
+    const period = lfm.parsePeriod(req.query.period);
+
+    const [info, artists, tracks, albums, recent] = await Promise.all([
+      lfm.getUserInfo(username),
+      lfm.getTopArtists(username, period),
+      lfm.getTopTracks(username, period),
+      lfm.getTopAlbums(username, period),
+      lfm.getRecentTracks(username),
     ]);
+    const avatar = await lfm.fetchAvatar(lfm.pickImage(info.image));
 
-    const topArtists = topArtistsResponse.data.topartists.artist.slice(0, 5);
-    const topTracks = topTracksResponse.data.toptracks.track.slice(0, 5);
-    const topAlbums = topAlbumsResponse.data.topalbums.album.slice(0, 5);
-    const recentTracks = recentTracksResponse.data.recenttracks.track.slice(0, 5);
-    const profilePic = userInfoResponse.data.user.image[2]['#text'];
-    const totalScrobbles = userInfoResponse.data.user.playcount; 
-    const totalArtists = userInfoResponse.data.user.artist_count;
+    const col = (
+      items: string[],
+      x: number,
+      y0: number,
+      labelX: number,
+    ) =>
+      items
+        .map((label, i) => `
+        <text x="${x}" y="${y0 + i * 25}" class="index">${i + 1}.</text>
+        <text x="${labelX}" y="${y0 + i * 25}" class="item">${svg.escapeXML(label)}</text>`)
+        .join('');
 
-    const response = await axios.get(profilePic, { responseType: 'arraybuffer' });
-    const base64ProfilePic = Buffer.from(response.data, 'binary').toString('base64');
-    const fullProfilePic = `data:image/png;base64,${base64ProfilePic}`;
+    const artistLines = col(artists.map((a) => svg.truncate(a.name, 30)), 20, 210, 40);
+    const trackLines = col(
+      tracks.map((t) => svg.truncate(`${t.name} - ${t.artist?.name ?? 'Unknown'}`, 32)),
+      320, 210, 340,
+    );
+    const albumLines = col(
+      albums.map((a) => svg.truncate(`${a.name} - ${a.artist?.name ?? 'Unknown'}`, 30)),
+      20, 400, 40,
+    );
+    const recentLines = col(
+      recent.map((t) => svg.truncate(`${t.name} - ${t.artist?.['#text'] || 'Unknown'}`, 32)),
+      320, 400, 340,
+    );
 
-    let svgContent = `
-      <svg xmlns="http://www.w3.org/2000/svg" width="660" height="550" viewBox="0 0 660 550" fill="none">
-        <style>
-          .bg { fill: url(#grad); }
-          .title { font: bold 22px 'Segoe UI', sans-serif; fill: #ffffff; }
-          .section-title { font: bold 18px 'Segoe UI', sans-serif; fill: #ffd700; }
-          .item { font: 14px 'Segoe UI', sans-serif; fill: #f5f5f5; }
-          .index { font: bold 14px 'Segoe UI', sans-serif; fill: #ff6b6b; }
-          .profile { clip-path: circle(40px at center); }
-          .subtitle { font: italic 12px 'Segoe UI', sans-serif; fill: #e0e0e0; }
-          .stats { font: bold 12px 'Segoe UI', sans-serif; fill: #f5f5f5; }
-        </style>
+    const inner = `
+      <text x="20" y="40" class="title">Music Stats for ${svg.escapeXML(username)}</text>
+      <text x="20" y="60" class="subtitle">Top Artists, Tracks, and Albums (${period})</text>
 
-        <defs>
-          <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" style="stop-color:#1a2a3a;stop-opacity:1" />
-            <stop offset="100%" style="stop-color:#3d6073;stop-opacity:1" />
-          </linearGradient>
-        </defs>
+      ${svg.avatarCircle(avatar, 600, 65, 40)}
 
-        <rect width="660" height="550" class="bg"/>
+      <text x="20" y="120" class="stats">Total Scrobbles: ${svg.formatNumber(info.playcount)}</text>
+      <text x="20" y="140" class="stats">Total Artists: ${svg.formatNumber(info.artist_count)}</text>
 
-        <text x="20" y="40" class="title">Music Stats for ${escapeXML(username || '')}</text>
-        <text x="20" y="60" class="subtitle">Top Artists, Tracks, and Albums</text>
+      <text x="20" y="180" class="section-title">Top 5 Artists</text>
+      ${artistLines}
+      <text x="320" y="180" class="section-title">Top 5 Tracks</text>
+      ${trackLines}
+      <text x="20" y="370" class="section-title">Top 5 Albums</text>
+      ${albumLines}
+      <text x="320" y="370" class="section-title">Recent 5 Tracks</text>
+      ${recentLines}`;
 
-        <image href="${fullProfilePic}" x="560" y="25" height="80" width="80" class="profile"/>
-
-        <text x="20" y="120" class="stats">Total Scrobbles: ${totalScrobbles}</text>
-        <text x="20" y="140" class="stats">Total Artists: ${totalArtists}</text>
-
-        <text x="20" y="180" class="section-title">Top 5 Artists</text>
-    `;
-
-    topArtists.forEach((artist: any, index: number) => {
-      svgContent += `
-        <text x="20" y="${210 + index * 25}" class="index">${index + 1}.</text>
-        <text x="40" y="${210 + index * 25}" class="item">${escapeXML(artist.name)}</text>`;
-    });
-
-    svgContent += `
-        <text x="320" y="180" class="section-title">Top 5 Songs</text>`;
-
-    topTracks.forEach((track: any, index: number) => {
-      svgContent += `
-        <text x="320" y="${210 + index * 25}" class="index">${index + 1}.</text>
-        <text x="340" y="${210 + index * 25}" class="item">${escapeXML(track.name)} - ${escapeXML(track.artist.name)}</text>`;
-    });
-
-    svgContent += `
-        <text x="20" y="370" class="section-title">Top 5 Albums</text>`;
-
-    topAlbums.forEach((album: any, index: number) => {
-      svgContent += `
-        <text x="20" y="${400 + index * 25}" class="index">${index + 1}.</text>
-        <text x="40" y="${400 + index * 25}" class="item">${escapeXML(album.name)} - ${escapeXML(album.artist.name)}</text>`;
-    });
-
-    svgContent += `
-        <text x="320" y="370" class="section-title">Recent 5 Tracks</text>`;
-
-    recentTracks.forEach((track: any, index: number) => {
-      const artistName = track.artist['#text'] || 'Unknown Artist';
-      svgContent += `
-        <text x="320" y="${400 + index * 25}" class="index">${index + 1}.</text>
-        <text x="340" y="${400 + index * 25}" class="item">${escapeXML(track.name)} - ${escapeXML(artistName)}</text>`;
-    });
-
-    svgContent += `</svg>`;
-
-    res.setHeader('Content-Type', 'image/svg+xml');
-    res.status(200).send(svgContent);
-  } catch (error) {
-    res.status(500).json({ error: 'Error fetching data from Last.fm' });
+    return svg.sendSvg(res, svg.card(660, 550, theme, inner), 21600);
+  } catch (e) {
+    return svg.sendError(res, e instanceof lfm.LastfmError ? e.message : 'Error fetching data from Last.fm', theme);
   }
 }

--- a/src/pages/api/recent.ts
+++ b/src/pages/api/recent.ts
@@ -1,79 +1,39 @@
-import axios from 'axios';
-import { NextApiRequest, NextApiResponse } from 'next';
-
-function escapeXML(str: string) {
-  return str.replace(/&/g, "&amp;")
-            .replace(/</g, "&lt;")
-            .replace(/>/g, "&gt;")
-            .replace(/"/g, "&quot;")
-            .replace(/'/g, "&#039;")
-            .replace(/\$/g, "&#36;")
-            .replace(/%/g, "&#37;");
-}
+import type { NextApiRequest, NextApiResponse } from 'next';
+import * as svg from '@/lib/svg';
+import * as lfm from '@/lib/lastfm';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const username = Array.isArray(req.query.username) ? req.query.username[0] : req.query.username;
-  if (!username) {
-    res.status(400).json({ error: 'Username is required' });
-    return;
-  }
-  const apiKey = process.env.LASTFM_API_KEY;
-
-  const lastFmRecentTracksUrl = `http://ws.audioscrobbler.com/2.0/?method=user.getrecenttracks&user=${username}&api_key=${apiKey}&format=json`;
-  const lastFmUserInfoUrl = `http://ws.audioscrobbler.com/2.0/?method=user.getinfo&user=${username}&api_key=${apiKey}&format=json`;
-
+  const theme = svg.getTheme(req.query.theme);
   try {
-    const [recentTracksResponse, userInfoResponse] = await Promise.all([
-      axios.get(lastFmRecentTracksUrl),
-      axios.get(lastFmUserInfoUrl),
+    const username = lfm.parseUsername(req.query.username);
+    if (!username) return svg.sendError(res, 'username query param is required', theme);
+
+    const [info, recent] = await Promise.all([
+      lfm.getUserInfo(username),
+      lfm.getRecentTracks(username),
     ]);
+    const avatar = await lfm.fetchAvatar(lfm.pickImage(info.image));
 
-    const recentTracks = recentTracksResponse.data.recenttracks.track.slice(0, 5);
-    const profilePic = userInfoResponse.data.user.image[2]['#text']; 
-    const response = await axios.get(profilePic, { responseType: 'arraybuffer' });
-    const base64ProfilePic = Buffer.from(response.data, 'binary').toString('base64');
-    const fullProfilePic = `data:image/png;base64,${base64ProfilePic}`;
+    const rows = recent
+      .map((t, i) => {
+        const artist = t.artist?.['#text'] || 'Unknown Artist';
+        const nowPlaying = t['@attr']?.nowplaying ? '  ♫' : '';
+        const label = svg.truncate(`${t.name || 'Unknown Track'} - ${artist}`, 50);
+        return `
+        <text x="20" y="${100 + i * 18}" class="index">${i + 1}.</text>
+        <text x="50" y="${100 + i * 18}" class="item">${svg.escapeXML(label)}${nowPlaying}</text>`;
+      })
+      .join('');
 
-    let svgContent = `
-      <svg xmlns="http://www.w3.org/2000/svg" width="500" height="200" viewBox="0 0 500 200" fill="none">
-        <style>
-          .bg { fill: url(#grad); }
-          .title { font: bold 22px 'Segoe UI', sans-serif; fill: #ffffff; }
-          .section-title { font: bold 18px 'Segoe UI', sans-serif; fill: #ffd700; }
-          .item { font: 12px 'Segoe UI', sans-serif; fill: #f5f5f5; }
-          .index { font: bold 12px 'Segoe UI', sans-serif; fill: #ff6b6b; }
-        </style>
-        <defs>
-          <linearGradient id="grad" x1="0%" y1="0%" x2="100%">
-            <stop offset="0%" style="stop-color:#1a2a3a;stop-opacity:1" />
-            <stop offset="100%" style="stop-color:#3d6073;stop-opacity:1" />
-          </linearGradient>
-          <clipPath id="clipCircle">
-            <circle cx="440" cy="55" r="40" />
-          </clipPath>
-        </defs>
-        <rect width="500" height="200" class="bg"/>
+    const inner = `
+      ${svg.avatarCircle(avatar, 440, 55, 40)}
+      <text x="20" y="40" class="title">Recent Tracks for ${svg.escapeXML(username)}</text>
+      <text x="20" y="80" class="section-title">Recent 5 Tracks</text>
+      ${rows}`;
 
-        <circle cx="440" cy="55" r="40" fill="white" />
-        <image href="${fullProfilePic}" x="400" y="15" height="80" width="80" clip-path="url(#clipCircle)" />
-
-        <text x="20" y="40" class="title">Recent Tracks for ${escapeXML(username)}</text>
-        <text x="20" y="80" class="section-title">Recent 5 Tracks</text>
-    `;
-
-    recentTracks.forEach((track: any, index: number) => {
-      const artistName = track.artist['#text'] || 'Unknown Artist';
-      const trackName = track.name || 'Unknown Track';
-      svgContent += `
-        <text x="20" y="${100 + index * 18}" class="index">${index + 1}.</text>
-        <text x="50" y="${100 + index * 18}" class="item">${escapeXML(trackName)} - ${escapeXML(artistName)}</text>`;
-    });
-
-    svgContent += `</svg>`;
-
-    res.setHeader('Content-Type', 'image/svg+xml');
-    res.status(200).send(svgContent);
-  } catch (error) {
-    res.status(500).json({ error: 'Error fetching data from Last.fm' });
+    // Shorter cache: recent activity changes often
+    return svg.sendSvg(res, svg.card(500, 200, theme, inner), 300);
+  } catch (e) {
+    return svg.sendError(res, e instanceof lfm.LastfmError ? e.message : 'Error fetching data from Last.fm', theme);
   }
 }

--- a/src/pages/api/top-albums.ts
+++ b/src/pages/api/top-albums.ts
@@ -1,74 +1,37 @@
-import axios from 'axios';
-import { NextApiRequest, NextApiResponse } from 'next';
-
-function escapeXML(str: string) {
-  return str.replace(/&/g, "&amp;")
-            .replace(/</g, "&lt;")
-            .replace(/>/g, "&gt;")
-            .replace(/"/g, "&quot;")
-            .replace(/'/g, "&#039;")
-            .replace(/\$/g, "&#36;")  
-            .replace(/%/g, "&#37;");  
-}
+import type { NextApiRequest, NextApiResponse } from 'next';
+import * as svg from '@/lib/svg';
+import * as lfm from '@/lib/lastfm';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const username = Array.isArray(req.query.username) ? req.query.username[0] : req.query.username;
-  const apiKey = process.env.LASTFM_API_KEY;
-
-  const lastFmTopAlbumsUrl = `http://ws.audioscrobbler.com/2.0/?method=user.gettopalbums&user=${username}&api_key=${apiKey}&format=json&period=overall`;
-  const lastFmUserInfoUrl = `http://ws.audioscrobbler.com/2.0/?method=user.getinfo&user=${username}&api_key=${apiKey}&format=json`;
-
+  const theme = svg.getTheme(req.query.theme);
   try {
-    const [topAlbumsResponse, userInfoResponse] = await Promise.all([
-      axios.get(lastFmTopAlbumsUrl),
-      axios.get(lastFmUserInfoUrl),
+    const username = lfm.parseUsername(req.query.username);
+    if (!username) return svg.sendError(res, 'username query param is required', theme);
+    const period = lfm.parsePeriod(req.query.period);
+
+    const [info, albums] = await Promise.all([
+      lfm.getUserInfo(username),
+      lfm.getTopAlbums(username, period),
     ]);
+    const avatar = await lfm.fetchAvatar(lfm.pickImage(info.image));
 
-    const topAlbums = topAlbumsResponse.data.topalbums.album.slice(0, 5);
-    const profilePic = userInfoResponse.data.user.image[2]['#text']; 
-    const response = await axios.get(profilePic, { responseType: 'arraybuffer' });
-    const base64ProfilePic = Buffer.from(response.data, 'binary').toString('base64');
-    const fullProfilePic = `data:image/png;base64,${base64ProfilePic}`;
+    const rows = albums
+      .map((a, i) => {
+        const label = svg.truncate(`${a.name} - ${a.artist?.name ?? 'Unknown Artist'}`, 52);
+        return `
+        <text x="20" y="${100 + i * 18}" class="index">${i + 1}.</text>
+        <text x="50" y="${100 + i * 18}" class="item">${svg.escapeXML(label)}</text>`;
+      })
+      .join('');
 
-    let svgContent = `
-      <svg xmlns="http://www.w3.org/2000/svg" width="500" height="200" viewBox="0 0 500 200" fill="none">
-        <style>
-          .bg { fill: url(#grad); }
-          .title { font: bold 22px 'Segoe UI', sans-serif; fill: #ffffff; }
-          .section-title { font: bold 18px 'Segoe UI', sans-serif; fill: #ffd700; }
-          .item { font: 12px 'Segoe UI', sans-serif; fill: #f5f5f5; }
-          .index { font: bold 12px 'Segoe UI', sans-serif; fill: #ff6b6b; }
-        </style>
-        <defs>
-          <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" style="stop-color:#1a2a3a;stop-opacity:1" />
-            <stop offset="100%" style="stop-color:#3d6073;stop-opacity:1" />
-          </linearGradient>
-        </defs>
-        <rect width="500" height="200" class="bg"/>
+    const inner = `
+      ${svg.avatarCircle(avatar, 440, 55, 40)}
+      <text x="20" y="40" class="title">Top Albums for ${svg.escapeXML(username)}</text>
+      <text x="20" y="80" class="section-title">Top 5 Albums</text>
+      ${rows}`;
 
-        <!-- Profile Picture -->
-        <circle cx="440" cy="55" r="40" fill="white" />
-        <clipPath id="clipCircle">
-          <circle cx="440" cy="55" r="40" />
-        </clipPath>
-        <image href="${fullProfilePic}" x="400" y="15" height="80" width="80" clip-path="url(#clipCircle)" />
-
-        <text x="20" y="40" class="title">Top Albums for ${escapeXML(username || '')}</text>
-        <text x="20" y="80" class="section-title">Top 5 Albums</text>
-    `;
-
-    topAlbums.forEach((album: any, index: number) => {
-      svgContent += `
-        <text x="20" y="${100 + index * 18}" class="index">${index + 1}.</text>
-        <text x="50" y="${100 + index * 18}" class="item">${escapeXML(album.name)} - ${escapeXML(album.artist.name)}</text>`;
-    });
-
-    svgContent += `</svg>`;
-
-    res.setHeader('Content-Type', 'image/svg+xml');
-    res.status(200).send(svgContent);
-  } catch (error) {
-    res.status(500).json({ error: 'Error fetching data from Last.fm' });
+    return svg.sendSvg(res, svg.card(500, 200, theme, inner), 21600);
+  } catch (e) {
+    return svg.sendError(res, e instanceof lfm.LastfmError ? e.message : 'Error fetching data from Last.fm', theme);
   }
 }

--- a/src/pages/api/top-artists.ts
+++ b/src/pages/api/top-artists.ts
@@ -1,75 +1,34 @@
-import axios from 'axios';
-import { NextApiRequest, NextApiResponse } from 'next';
-
-function escapeXML(str: string) {
-  return str.replace(/&/g, "&amp;")
-            .replace(/</g, "&lt;")
-            .replace(/>/g, "&gt;")
-            .replace(/"/g, "&quot;")
-            .replace(/'/g, "&#039;")
-            .replace(/\$/g, "&#36;")  
-            .replace(/%/g, "&#37;");  
-}
+import type { NextApiRequest, NextApiResponse } from 'next';
+import * as svg from '@/lib/svg';
+import * as lfm from '@/lib/lastfm';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const username = Array.isArray(req.query.username) ? req.query.username[0] : req.query.username;
-  const apiKey = process.env.LASTFM_API_KEY;
-
-  const lastFmTopArtistsUrl = `http://ws.audioscrobbler.com/2.0/?method=user.gettopartists&user=${username}&api_key=${apiKey}&format=json&period=overall`;
-  const lastFmUserInfoUrl = `http://ws.audioscrobbler.com/2.0/?method=user.getinfo&user=${username}&api_key=${apiKey}&format=json`;
-
+  const theme = svg.getTheme(req.query.theme);
   try {
-    const [topArtistsResponse, userInfoResponse] = await Promise.all([
-      axios.get(lastFmTopArtistsUrl),
-      axios.get(lastFmUserInfoUrl),
+    const username = lfm.parseUsername(req.query.username);
+    if (!username) return svg.sendError(res, 'username query param is required', theme);
+    const period = lfm.parsePeriod(req.query.period);
+
+    const [info, artists] = await Promise.all([
+      lfm.getUserInfo(username),
+      lfm.getTopArtists(username, period),
     ]);
+    const avatar = await lfm.fetchAvatar(lfm.pickImage(info.image));
 
-    const topArtists = topArtistsResponse.data.topartists.artist.slice(0, 5);
-    const profilePic = userInfoResponse.data.user.image[2]['#text']; 
+    const rows = artists
+      .map((a, i) => `
+        <text x="20" y="${100 + i * 18}" class="index">${i + 1}.</text>
+        <text x="50" y="${100 + i * 18}" class="item">${svg.escapeXML(svg.truncate(a.name, 48))}</text>`)
+      .join('');
 
-    const response = await axios.get(profilePic, { responseType: 'arraybuffer' });
-    const base64ProfilePic = Buffer.from(response.data, 'binary').toString('base64');
-    const fullProfilePic = `data:image/png;base64,${base64ProfilePic}`;
+    const inner = `
+      ${svg.avatarCircle(avatar, 440, 55, 40)}
+      <text x="20" y="40" class="title">Top Artists for ${svg.escapeXML(username)}</text>
+      <text x="20" y="80" class="section-title">Top 5 Artists</text>
+      ${rows}`;
 
-    let svgContent = `
-      <svg xmlns="http://www.w3.org/2000/svg" width="500" height="200" viewBox="0 0 500 200" fill="none">
-        <style>
-          .bg { fill: url(#grad); }
-          .title { font: bold 22px 'Segoe UI', sans-serif; fill: #ffffff; }
-          .section-title { font: bold 18px 'Segoe UI', sans-serif; fill: #ffd700; }
-          .item { font: 12px 'Segoe UI', sans-serif; fill: #f5f5f5; }
-          .index { font: bold 12px 'Segoe UI', sans-serif; fill: #ff6b6b; }
-        </style>
-        <defs>
-          <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" style="stop-color:#1a2a3a;stop-opacity:1" />
-            <stop offset="100%" style="stop-color:#3d6073;stop-opacity:1" />
-          </linearGradient>
-        </defs>
-        <rect width="500" height="200" class="bg"/>
-
-        <!-- Profile Picture -->
-        <circle cx="440" cy="55" r="40" fill="white" />
-        <clipPath id="clipCircle">
-          <circle cx="440" cy="55" r="40" />
-        </clipPath>
-        <image href="${fullProfilePic}" x="400" y="15" height="80" width="80" clip-path="url(#clipCircle)" />
-
-        <text x="20" y="40" class="title">Top Artists for ${escapeXML(username || '')}</text>
-        <text x="20" y="80" class="section-title">Top 5 Artists</text>
-    `;
-
-    topArtists.forEach((artist: any, index: number) => {
-      svgContent += `
-        <text x="20" y="${100 + index * 18}" class="index">${index + 1}.</text>
-        <text x="50" y="${100 + index * 18}" class="item">${escapeXML(artist.name)}</text>`;
-    });
-
-    svgContent += `</svg>`;
-
-    res.setHeader('Content-Type', 'image/svg+xml');
-    res.status(200).send(svgContent);
-  } catch (error) {
-    res.status(500).json({ error: 'Error fetching data from Last.fm' });
+    return svg.sendSvg(res, svg.card(500, 200, theme, inner), 21600);
+  } catch (e) {
+    return svg.sendError(res, e instanceof lfm.LastfmError ? e.message : 'Error fetching data from Last.fm', theme);
   }
 }

--- a/src/pages/api/top-tracks.ts
+++ b/src/pages/api/top-tracks.ts
@@ -1,76 +1,37 @@
-import axios from 'axios';
-import { NextApiRequest, NextApiResponse } from 'next';
-
-function escapeXML(str: string) {
-  return str.replace(/&/g, "&amp;")
-            .replace(/</g, "&lt;")
-            .replace(/>/g, "&gt;")
-            .replace(/"/g, "&quot;")
-            .replace(/'/g, "&#039;")
-            .replace(/\$/g, "&#36;")  
-            .replace(/%/g, "&#37;");  
-}
+import type { NextApiRequest, NextApiResponse } from 'next';
+import * as svg from '@/lib/svg';
+import * as lfm from '@/lib/lastfm';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const username = Array.isArray(req.query.username) ? req.query.username[0] : req.query.username;
-  const apiKey = process.env.LASTFM_API_KEY;
-
-  const lastFmTopTracksUrl = `http://ws.audioscrobbler.com/2.0/?method=user.gettoptracks&user=${username}&api_key=${apiKey}&format=json&period=overall`;
-  const lastFmUserInfoUrl = `http://ws.audioscrobbler.com/2.0/?method=user.getinfo&user=${username}&api_key=${apiKey}&format=json`;
-
+  const theme = svg.getTheme(req.query.theme);
   try {
-    const [topTracksResponse, userInfoResponse] = await Promise.all([
-      axios.get(lastFmTopTracksUrl),
-      axios.get(lastFmUserInfoUrl),
+    const username = lfm.parseUsername(req.query.username);
+    if (!username) return svg.sendError(res, 'username query param is required', theme);
+    const period = lfm.parsePeriod(req.query.period);
+
+    const [info, tracks] = await Promise.all([
+      lfm.getUserInfo(username),
+      lfm.getTopTracks(username, period),
     ]);
+    const avatar = await lfm.fetchAvatar(lfm.pickImage(info.image));
 
-    const topTracks = topTracksResponse.data.toptracks.track.slice(0, 5);
-    const profilePic = userInfoResponse.data.user.image[2]['#text']; 
-    const response = await axios.get(profilePic, { responseType: 'arraybuffer' });
-    const base64ProfilePic = Buffer.from(response.data, 'binary').toString('base64');
-    const fullProfilePic = `data:image/png;base64,${base64ProfilePic}`;
+    const rows = tracks
+      .map((t, i) => {
+        const label = svg.truncate(`${t.name} - ${t.artist?.name ?? 'Unknown Artist'}`, 52);
+        return `
+        <text x="20" y="${100 + i * 18}" class="index">${i + 1}.</text>
+        <text x="50" y="${100 + i * 18}" class="item">${svg.escapeXML(label)}</text>`;
+      })
+      .join('');
 
-    let svgContent = `
-      <svg xmlns="http://www.w3.org/2000/svg" width="500" height="200" viewBox="0 0 500 200" fill="none">
-        <style>
-          .bg { fill: url(#grad); }
-          .title { font: bold 22px 'Segoe UI', sans-serif; fill: #ffffff; }
-          .section-title { font: bold 18px 'Segoe UI', sans-serif; fill: #ffd700; }
-          .item { font: 12px 'Segoe UI', sans-serif; fill: #f5f5f5; }
-          .index { font: bold 12px 'Segoe UI', sans-serif; fill: #ff6b6b; }
-        </style>
-        <defs>
-          <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" style="stop-color:#1a2a3a;stop-opacity:1" />
-            <stop offset="100%" style="stop-color:#3d6073;stop-opacity:1" />
-          </linearGradient>
-        </defs>
-        <rect width="500" height="200" class="bg"/>
+    const inner = `
+      ${svg.avatarCircle(avatar, 440, 55, 40)}
+      <text x="20" y="40" class="title">Top Tracks for ${svg.escapeXML(username)}</text>
+      <text x="20" y="80" class="section-title">Top 5 Tracks</text>
+      ${rows}`;
 
-        <!-- Profile Picture -->
-        <circle cx="440" cy="55" r="40" fill="white" />
-        <clipPath id="clipCircle">
-          <circle cx="440" cy="55" r="40" />
-        </clipPath>
-        <image href="${fullProfilePic}" x="400" y="15" height="80" width="80" clip-path="url(#clipCircle)" />
-
-        <text x="20" y="40" class="title">Top Tracks for ${escapeXML(username || 'Unknown User')}</text>
-        <text x="20" y="80" class="section-title">Top 5 Tracks</text>
-    `;
-
-    topTracks.forEach((track: any, index: number) => {
-      const trackName = escapeXML(track.name || 'Unknown Track');
-      const artistName = escapeXML(track.artist.name || 'Unknown Artist'); 
-      svgContent += `
-        <text x="20" y="${100 + index * 18}" class="index">${index + 1}.</text>
-        <text x="50" y="${100 + index * 18}" class="item">${trackName} - ${artistName}</text>`;
-    });
-
-    svgContent += `</svg>`;
-
-    res.setHeader('Content-Type', 'image/svg+xml');
-    res.status(200).send(svgContent);
-  } catch (error) {
-    res.status(500).json({ error: 'Error fetching data from Last.fm' });
+    return svg.sendSvg(res, svg.card(500, 200, theme, inner), 21600);
+  } catch (e) {
+    return svg.sendError(res, e instanceof lfm.LastfmError ? e.message : 'Error fetching data from Last.fm', theme);
   }
 }


### PR DESCRIPTION

- The cards hit Last.fm on every single render with no caching, so I added Cache-Control headers (6h for stats, 5min for recent). Cuts down the API calls a lot and loads faster.
- When a username was wrong or something failed, the endpoint returned a JSON 500 — which just shows up as a broken image in a README. Changed it to return a small SVG error card instead, so you actually see what went wrong.
- Added proper username validation and handling for Last.fm's `{error}` responses across all endpoints (only `recent` had a check before).
- Switched the Last.fm API calls from http:// to https://.
- Added a `?theme=` option with a few palettes (dark, light, dracula, gruvbox, tokyonight, radical, nord, catppuccin) so the card can match different profiles.
- Pulled the shared bits (escapeXML, the SVG boilerplate, the fetch logic) into `src/lib/lastfm.ts` and `svg.ts` since they were copy-pasted across all 5 routes.
- Small stuff too: long names now truncate instead of overflowing, scrobble counts are comma-formatted, recent tracks are capped at 5 (the now-playing entry was making it 6), and the top-* endpoints now actually respect the `period` param.
